### PR TITLE
Bug fix replace mesh

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,20 +73,19 @@ The momentum is defined on the first Brillouin zone captured by a 2D k-mesh.
     using GreenFunc
     using GreenFunc: BrillouinZoneMeshes
 
-    DIM = 2
+    DIM, nk = 2, 8
     latvec = [1.0 0.0; 0.0 1.0] .* 2π
-    nk = 8
     bzmesh = BrillouinZoneMeshes.BaseMesh.UniformMesh{DIM, nk}([0.0, 0.0], latvec)
-    wmesh = MeshGrids.ImFreq(10.0, FERMION)
-    g_freq =  MeshArray(bzmesh, wmesh; dtype=ComplexF64)
+    ωₙmesh = MeshGrids.ImFreq(10.0, FERMION)
+    g_freq =  MeshArray(bzmesh, ωₙmesh; dtype=ComplexF64)
 
     t = 1.0
     for ind in eachindex(g_freq)
         q = g_freq.mesh[1][ind[1]]
-        ω_n = g_freq.mesh[2][ind[2]]
-        println(q, ω_n)
-        g_freq[ind] = 1/(im*ω_n - (-2*t*sum(cos.(q))))
+        ωₙ = g_freq.mesh[2][ind[2]]
+        g_freq[ind] = 1/(ωₙ*im - (-2*t*sum(cos.(q))))
     end
+    g_tau = g_freq |> to_dlr |> to_imtime #fourier transform to (k, tau) domain
 ```
 
 - For lattice systems with multidimenstional Brillouin zone, the momentum grids can be better handled with the BrillouinZoneMeshes package. Here a `UniformMesh{DIM,N}(origin, latvec)` generates a linearly spaced momentum mesh on the first Brillouin zone defined by origin and lattice vectors given. For more detail see https://github.com/numericalEFT/BrillouinZoneMeshes.jl.
@@ -212,11 +211,11 @@ is consistent with Triqs counterpart, while the order of cartesian index
 and lattice vector reversed.
 - Here's a table of 2D converted mesh v.s. the Triqs counterpart:
 
-|Object | Triqs | GreenFunc.jl|
-| ------ | ------- | ------------- |
-| Linear index | mk[i]=(x, y, 0) | mkj[i]= (x, y) |
+| Object          | Triqs             | GreenFunc.jl   |
+| --------------- | ----------------- | -------------- |
+| Linear index    | mk[i]=(x, y, 0)   | mkj[i]= (x, y) |
 | Cartesian index | mk[i,j]=(x, y, 0) | mkj[j,i]=(x,y) |
-| Lattice vector | (a1, a2) | (a2, a1) |
+| Lattice vector  | (a1, a2)          | (a2, a1)       |
 
 ### Example 7: Load Triqs Greens function of a Hubbard Lattice
 

--- a/src/green/transform.jl
+++ b/src/green/transform.jl
@@ -18,9 +18,9 @@ end
 
     types = fieldtypes(MT)
     if types[1] == OldM
-        m = :(mesh_new)
+        m = :(mesh_new,)
     else
-        m = :(meshes[1])
+        m = :(meshes[1],)
     end
 
     for (i, t) in enumerate(types)
@@ -29,9 +29,9 @@ end
             continue
         else
             if t == OldM
-                m = :($m, mesh_new)
+                m = :($m..., mesh_new)
             else
-                m = :($m, meshes[$i])
+                m = :($m..., meshes[$i])
             end
         end
     end
@@ -39,7 +39,7 @@ end
 
     # the following will always return a tuple
     if length(types) == 1
-        return :($m,)
+        return :($m)
     else
         return :($m)
     end

--- a/src/meshgrids/imfreq.jl
+++ b/src/meshgrids/imfreq.jl
@@ -54,9 +54,9 @@ function ImFreq(β, isFermi::Bool=false;
     symmetry=:none,
     grid::Union{AbstractGrid,AbstractVector,Nothing}=nothing
 )
+    dlr = DLRGrid(Euv, β, rtol, isFermi, :none)
     if isnothing(grid)
         # TODO: replace the dlr.n with a non-dlr grid. User don't want dlr if it is not initialized with a dlr
-        dlr = DLRGrid(Euv, β, rtol, isFermi, :none)
         grid = SimpleG.Arbitrary{Int}(dlr.n)
     elseif (grid isa AbstractVector)
         grid = SimpleG.Arbitrary{Int}(Int.(grid))
@@ -66,7 +66,7 @@ function ImFreq(β, isFermi::Bool=false;
 
     @assert issorted(grid) "The grid should be sorted."
     @assert eltype(grid) <: Int "Matsubara-frequency grid should be Int."
-    return ImFreq{dtype,typeof(grid),Nothing}(grid, β, Euv, isFermi, symmetry, rtol, nothing)
+    return ImFreq{dtype,typeof(grid),typeof(dlr)}(grid, β, Euv, isFermi, symmetry, rtol, dlr)
 end
 
 """

--- a/src/meshgrids/imtime.jl
+++ b/src/meshgrids/imtime.jl
@@ -54,8 +54,9 @@ function ImTime(β, isFermi::Bool=false;
     symmetry=:none,
     grid::Union{AbstractGrid,AbstractVector,Nothing}=nothing
 )
+
+    dlr = DLRGrid(Euv, β, rtol, isFermi, :none)
     if isnothing(grid)
-        dlr = DLRGrid(Euv, β, rtol, isFermi, :none)
         grid = SimpleG.Arbitrary{dtype}(dlr.τ)
         # grid = SimpleG.Uniform{dtype}([0, β], Int(round(β / resolution)))
         # grid = CompositeGrid.LogDensedGrid(:uniform, [0.0, β], [0.0, β], 8, 1 / Euv, 8) #roughly ~100 points if resolution = β/128
@@ -67,7 +68,7 @@ function ImTime(β, isFermi::Bool=false;
     @assert grid[1] >= 0 && grid[end] <= β "The grid should be in the range [0, β]."
     @assert issorted(grid) "The grid should be sorted."
     @assert eltype(grid) == dtype "The type of grid should be the same as dtype = $dtype"
-    return ImTime{dtype,typeof(grid),Nothing}(grid, β, Euv, isFermi, symmetry, rtol, nothing)
+    return ImTime{dtype,typeof(grid),typeof(dlr)}(grid, β, Euv, isFermi, symmetry, rtol, dlr)
 end
 
 """

--- a/test/test_transform.jl
+++ b/test/test_transform.jl
@@ -9,6 +9,11 @@ SemiCircle(dlr, grid, type) = Sample.SemiCircle(dlr.Euv, dlr.β, dlr.isFermi, gr
         @test GreenFunc._find_mesh(typeof(g.mesh), DLRFreq) == 2
         @test GreenFunc._find_mesh(typeof(g.mesh), Int) == 0 # not found
 
+        moremeshes = (mesh1, mesh2, mesh1)
+        replacedmeshes = GreenFunc._replace_mesh(moremeshes, mesh2, mesh1)
+        # println(typeof(replacedmeshes))
+        @test replacedmeshes == (mesh1, mesh1, mesh1)
+
         g_freq = dlr_to_imfreq(g)
         Gτ = SemiCircle(mesh2.dlr, mesh2.dlr.τ, :τ)
         Gn = SemiCircle(mesh2.dlr, mesh2.dlr.n, :n)

--- a/test/test_transform.jl
+++ b/test/test_transform.jl
@@ -54,10 +54,12 @@ SemiCircle(dlr, grid, type) = Sample.SemiCircle(dlr.Euv, dlr.β, dlr.isFermi, gr
         @test err < 50 * rtol
 
 
+        g_freq1 << g_dlr
         @time g_freq1 << g_dlr
         err = maximum(abs.(g_freq1.data[1, :] .- Gn))
         printstyled("test  imfreq<<dlr $err\n", color=:white)
         @test err < 50 * rtol
+        g_time << g_dlr
         @time g_time << g_dlr
         err = maximum(abs.(g_time.data[1, :] .- Gτ))
         printstyled("test  imtime<<dlr $err\n", color=:white)
@@ -66,6 +68,6 @@ SemiCircle(dlr, grid, type) = Sample.SemiCircle(dlr.Euv, dlr.β, dlr.isFermi, gr
 
 
     end
-    @time test_fourier(5, 100.0, FERMION)
-    @time test_fourier(5, 100.0, BOSON)
+    test_fourier(5, 100.0, FERMION)
+    test_fourier(5, 100.0, BOSON)
 end


### PR DESCRIPTION
fixed bug where _replace_mesh() returns (((mesh1, mesh2), mesh3), mesh4) instead of (mesh1, mesh2, mesh3, mesh4)