### PR TITLE
Add Julia 1.10 and 1.11 compatibility 

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,11 +14,11 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
-BrillouinZoneMeshes = "0.2.2"
+BrillouinZoneMeshes = "0.2"
 CompositeGrids = "0.1"
 Lehmann = "0.2"
 StaticArrays = "1"
-julia = "1.6, 1.7, 1.8, 1.9"
+julia = "1.6, 1.7, 1.8, 1.9, 1.10, 1.11"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
## Add Julia 1.10 and 1.11 compatibility
cf: issue #114

This PR adds support for Julia 1.10 and 1.11 by updating the compatibility constraints in Project.toml.

### Changes
- Added Julia 1.10 and 1.11 to supported versions
- Relaxed BrillouinZoneMeshes version constraint from "0.2.2" to "0.2"

### Motivation
Currently, GreenFunc.jl causes dependency conflicts with packages like DFTK.jl on Julia 1.10+. This simple change resolves these issues without breaking existing functionality.

### Testing
- Tested on Julia 1.11.6
- Verified compatibility with DFTK.jl v0.7.16
- All existing functionality remains intact
